### PR TITLE
Fix surge deploy step for Yarn

### DIFF
--- a/.github/workflows/surge_deploy.yaml
+++ b/.github/workflows/surge_deploy.yaml
@@ -13,7 +13,9 @@ jobs:
         with:
           node-version: 12
       - name: Prepare for Yarn Installation
-        run: curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+        run: |
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
       - name: install yarn
         run: sudo apt update && sudo apt install yarn
       - name: Build React App


### PR DESCRIPTION
## Summary
- split yarn prep commands in CI workflow

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68822ca14a44832ebf90abcf3a7b42a8